### PR TITLE
add types for uuid and string to the core library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.nesscomputing</groupId>
     <artifactId>ness-oss-parent</artifactId>
-    <version>6</version>
+    <version>9</version>
   </parent>
 
   <scm>
@@ -18,7 +18,7 @@
   <groupId>com.nesscomputing.components</groupId>
   <artifactId>ness-core</artifactId>
   <name>ness-core</name>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Ness base types component</description>
 
@@ -26,6 +26,22 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>1.9.7</version>
       <optional>true</optional>
     </dependency>
 
@@ -40,5 +56,12 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
       <version>1.9.7</version>
-      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/nesscomputing/types/PlatformId.java
+++ b/src/main/java/com/nesscomputing/types/PlatformId.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nesscomputing.types;
 
 import java.nio.ByteBuffer;

--- a/src/main/java/com/nesscomputing/types/PlatformId.java
+++ b/src/main/java/com/nesscomputing/types/PlatformId.java
@@ -20,6 +20,7 @@ import java.nio.LongBuffer;
 import java.util.UUID;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -28,6 +29,7 @@ import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonValue;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 
 /**
  * Typed UUID which ensures you do not mix ids of one service with another.
@@ -46,6 +48,7 @@ public final class PlatformId<T>
 
     private static final Function<UUID, PlatformId<?>> FROM_UUID = new Function<UUID, PlatformId<?>>() {
         @Override
+        @CheckForNull
         public PlatformId<?> apply(@Nullable final UUID uuid)
         {
             return PlatformId.fromUuid(uuid);
@@ -54,6 +57,7 @@ public final class PlatformId<T>
 
     private static final Function<String, PlatformId<?>> FROM_STRING = new Function<String, PlatformId<?>>() {
         @Override
+        @CheckForNull
         public PlatformId<?> apply(@Nullable final String input)
         {
             return PlatformId.valueOf(input);
@@ -88,13 +92,14 @@ public final class PlatformId<T>
 
     private static final Function<byte[], PlatformId<?>> FROM_BYTES = new Function<byte[], PlatformId<?>>() {
         @Override
+        @CheckForNull
         public PlatformId<?> apply(@Nullable final byte[] input) {
             if (input != null) {
                 LongBuffer buffer = ByteBuffer.wrap(input).asLongBuffer();
                 return PlatformId.fromUuid(new UUID(buffer.get(), buffer.get()));
             }
             else {
-                return PlatformId.valueOf(null);
+                return null;
             }
         }
     };
@@ -131,23 +136,27 @@ public final class PlatformId<T>
 
 
     @JsonCreator
+    @CheckForNull
     public static <T> PlatformId<T> valueOf(@Nullable final String value)
     {
-        return new PlatformId<T>(value == null ? null : UUID.fromString(value));
+        return value == null ? null : new PlatformId<T>(UUID.fromString(value));
     }
 
+    @CheckForNull
     public static <T> PlatformId<T> fromUuid(@Nullable final UUID uuid)
     {
-        return new PlatformId<T>(uuid == null ? null : uuid);
+        return uuid == null ? null : new PlatformId<T>(uuid);
     }
 
     private final UUID uuid;
 
-    private PlatformId(@Nullable final UUID uuid)
+    private PlatformId(@Nonnull final UUID uuid)
     {
+        Preconditions.checkArgument(uuid != null, "uuid can not be null");
         this.uuid = uuid;
     }
 
+    @Nonnull
     public UUID getId()
     {
         return uuid;
@@ -156,7 +165,7 @@ public final class PlatformId<T>
     @JsonValue
     public String getValue()
     {
-        return uuid == null ? null : uuid.toString();
+        return uuid.toString();
     }
 
     @Override

--- a/src/main/java/com/nesscomputing/types/PlatformId.java
+++ b/src/main/java/com/nesscomputing/types/PlatformId.java
@@ -1,0 +1,173 @@
+package com.nesscomputing.types;
+
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+import java.util.UUID;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+
+import com.google.common.base.Function;
+
+/**
+ * Typed UUID which ensures you do not mix ids of one service with another.
+ *
+ * @param <T> the type for which this ID can reference
+ */
+public final class PlatformId<T>
+{
+    private static final Function<PlatformId<?>, UUID> TO_UUID = new Function<PlatformId<?>, UUID>() {
+        @Override
+        @CheckForNull
+        public UUID apply(@Nullable final PlatformId<?> id) {
+            return id == null ? null : id.getId();
+        }
+    };
+
+    private static final Function<UUID, PlatformId<?>> FROM_UUID = new Function<UUID, PlatformId<?>>() {
+        @Override
+        public PlatformId<?> apply(@Nullable final UUID uuid)
+        {
+            return PlatformId.fromUuid(uuid);
+        }
+    };
+
+    private static final Function<String, PlatformId<?>> FROM_STRING = new Function<String, PlatformId<?>>() {
+        @Override
+        public PlatformId<?> apply(@Nullable final String input)
+        {
+            return PlatformId.valueOf(input);
+        }
+    };
+
+    private static final Function<PlatformId<?>, String> TO_STRING = new Function<PlatformId<?>, String>() {
+        @Override
+        @CheckForNull
+        public String apply(@Nullable final PlatformId<?> input)
+        {
+            return input == null ? null : input.getValue();
+        }
+    };
+
+    private static final Function<PlatformId<?>, byte[]> TO_BYTES = new Function<PlatformId<?>, byte[]>() {
+        @Override
+        @CheckForNull
+        public byte[] apply(@Nullable PlatformId<?> input) {
+            if (input != null) {
+                final ByteBuffer buffer = ByteBuffer.allocate(128 / 8);
+                final LongBuffer longBuffer = buffer.asLongBuffer();
+                longBuffer.put(input.uuid.getMostSignificantBits());
+                longBuffer.put(input.uuid.getLeastSignificantBits());
+                return buffer.array();
+            }
+            else {
+                return null;
+            }
+        }
+    };
+
+    private static final Function<byte[], PlatformId<?>> FROM_BYTES = new Function<byte[], PlatformId<?>>() {
+        @Override
+        public PlatformId<?> apply(@Nullable final byte[] input) {
+            if (input != null) {
+                LongBuffer buffer = ByteBuffer.wrap(input).asLongBuffer();
+                return PlatformId.fromUuid(new UUID(buffer.get(), buffer.get()));
+            }
+            else {
+                return PlatformId.valueOf(null);
+            }
+        }
+    };
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<byte[], PlatformId<T>> fromBytesFunction() {
+        return (Function) FROM_BYTES;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<UUID, PlatformId<T>> fromUuidFunction() {
+        return (Function) FROM_UUID;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<String, PlatformId<T>> fromStringFunction() {
+        return (Function) FROM_STRING;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<PlatformId<T>, byte[]> toBytesFunction() {
+        return (Function) TO_BYTES;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<PlatformId<T>, UUID> toUuidFunction() {
+        return (Function) TO_UUID;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<PlatformId<T>, String> toStringFunction() {
+        return (Function) TO_STRING;
+    }
+
+
+    @JsonCreator
+    public static <T> PlatformId<T> valueOf(@Nullable final String value)
+    {
+        return new PlatformId<T>(value == null ? null : UUID.fromString(value));
+    }
+
+    public static <T> PlatformId<T> fromUuid(@Nullable final UUID uuid)
+    {
+        return new PlatformId<T>(uuid == null ? null : uuid);
+    }
+
+    private final UUID uuid;
+
+    private PlatformId(@Nullable final UUID uuid)
+    {
+        this.uuid = uuid;
+    }
+
+    public UUID getId()
+    {
+        return uuid;
+    }
+
+    @JsonValue
+    public String getValue()
+    {
+        return uuid == null ? null : uuid.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PlatformId [uuid=" + uuid + "]";
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof PlatformId))
+            return false;
+        PlatformId<?> castOther = (PlatformId<?>) other;
+        return new EqualsBuilder().append(uuid, castOther.uuid).isEquals();
+    }
+
+    private transient int hashCode;
+
+
+    @Override
+    public int hashCode()
+    {
+        if (hashCode == 0) {
+            hashCode = new HashCodeBuilder().append(uuid).toHashCode();
+        }
+        return hashCode;
+    }
+}

--- a/src/main/java/com/nesscomputing/types/StringId.java
+++ b/src/main/java/com/nesscomputing/types/StringId.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nesscomputing.types;
+
+import java.util.Locale;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+
+/**
+ * A typed string. The value is case insensitive and by default lowercased.
+ */
+public final class StringId<T>
+{
+    private static final Function<String, StringId<?>> FROM_STRING = new Function<String, StringId<?>>() {
+        @Override
+        @CheckForNull
+        public StringId<?> apply(@Nullable final String input)
+        {
+            return StringId.valueOf(input);
+        }
+    };
+
+    private static final Function<StringId<?>, String> TO_STRING = new Function<StringId<?>, String>() {
+        @Override
+        @CheckForNull
+        public String apply(@Nullable final StringId<?> input)
+        {
+            return input == null ? null : input.getValue();
+        }
+    };
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<String, StringId<T>> fromStringFunction()
+    {
+        return (Function) FROM_STRING;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Function<StringId<T>, String> toStringFunction()
+    {
+        return (Function) TO_STRING;
+    }
+
+    @JsonCreator
+    public static <T> StringId<T> valueOf(@Nullable final String value)
+    {
+        return value == null ? null : new StringId<T>(value);
+    }
+
+    private final String value;
+
+    /**
+     * Creates a new typed String id.
+     */
+    private StringId(@Nonnull final String value)
+    {
+        Preconditions.checkArgument(value != null, "value must not be null!");
+        this.value = value.toLowerCase(Locale.ENGLISH);
+    }
+
+    @JsonValue
+    public String getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof StringId))
+            return false;
+        StringId<?> castOther = (StringId<?>) other;
+        return new EqualsBuilder().append(value, castOther.value).isEquals();
+    }
+
+    private transient int hashCode;
+
+    @Override
+    public int hashCode()
+    {
+        if (hashCode == 0) {
+            hashCode = new HashCodeBuilder().append(value).toHashCode();
+        }
+        return hashCode;
+    }
+
+    private transient String toString;
+
+    @Override
+    public String toString()
+    {
+        if (toString == null) {
+            toString = new ToStringBuilder(this).appendSuper(super.toString()).append("value", value).toString();
+        }
+        return toString;
+    }
+}

--- a/src/test/java/com/nesscomputing/types/TestPlatformId.java
+++ b/src/test/java/com/nesscomputing/types/TestPlatformId.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nesscomputing.types;
 
 import java.util.UUID;

--- a/src/test/java/com/nesscomputing/types/TestPlatformId.java
+++ b/src/test/java/com/nesscomputing/types/TestPlatformId.java
@@ -42,17 +42,7 @@ public class TestPlatformId
     @Test
     public void testNull()
     {
-        final UUID uuid = null;
-
-        final PlatformId<User> userId = PlatformId.fromUuid(uuid);
-        Assert.assertNotNull(userId);
-        Assert.assertNull(userId.getId());
-        Assert.assertNull(userId.getValue());
-        Assert.assertNotNull(userId.toString());
-
-        final PlatformId<User> userId2 = PlatformId.fromUuid(uuid);
-
-        Assert.assertEquals(userId, userId2);
+        Assert.assertNull(StringId.valueOf(null));
     }
 
     @Test
@@ -113,40 +103,37 @@ public class TestPlatformId
     @Test
     public void testBytesNull()
     {
-        final PlatformId<User> nullId = PlatformId.valueOf(null);
         final PlatformId<User> p1 = null;
         final Function<PlatformId<User>, byte[]> f1 = PlatformId.toBytesFunction();
         final Function<byte [], PlatformId<User>> f2 = PlatformId.fromBytesFunction();
         final byte [] value = f1.apply(p1);
         Assert.assertNull(value);
         final PlatformId<User> p2 = f2.apply(value);
-        Assert.assertEquals(nullId, p2);
+        Assert.assertNull(p2);
     }
 
     @Test
     public void testStringNull()
     {
-        final PlatformId<User> nullId = PlatformId.valueOf(null);
         final PlatformId<User> p1 = null;
         final Function<PlatformId<User>, String> f1 = PlatformId.toStringFunction();
         final Function<String, PlatformId<User>> f2 = PlatformId.fromStringFunction();
         final String value = f1.apply(p1);
         Assert.assertNull(value);
         final PlatformId<User> p2 = f2.apply(value);
-        Assert.assertEquals(nullId, p2);
+        Assert.assertNull(p2);
     }
 
     @Test
     public void testUUIDNull()
     {
-        final PlatformId<User> nullId = PlatformId.valueOf(null);
         final PlatformId<User> p1 = null;
         final Function<PlatformId<User>, UUID> f1 = PlatformId.toUuidFunction();
         final Function<UUID, PlatformId<User>> f2 = PlatformId.fromUuidFunction();
         final UUID value = f1.apply(p1);
         Assert.assertNull(value);
         final PlatformId<User> p2 = f2.apply(value);
-        Assert.assertEquals(nullId, p2);
+        Assert.assertNull(p2);
     }
 
 

--- a/src/test/java/com/nesscomputing/types/TestPlatformId.java
+++ b/src/test/java/com/nesscomputing/types/TestPlatformId.java
@@ -1,0 +1,147 @@
+package com.nesscomputing.types;
+
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Function;
+import com.google.inject.TypeLiteral;
+
+public class TestPlatformId
+{
+    @Test
+    public void testBasic()
+    {
+        final UUID uuid = UUID.randomUUID();
+
+        final PlatformId<User> userId = PlatformId.fromUuid(uuid);
+        Assert.assertNotNull(userId);
+        Assert.assertEquals(uuid, userId.getId());
+
+        final PlatformId<User> userId2 = PlatformId.fromUuid(uuid);
+
+        Assert.assertEquals(userId, userId2);
+    }
+
+    @Test
+    public void testNull()
+    {
+        final UUID uuid = null;
+
+        final PlatformId<User> userId = PlatformId.fromUuid(uuid);
+        Assert.assertNotNull(userId);
+        Assert.assertNull(userId.getId());
+        Assert.assertNull(userId.getValue());
+        Assert.assertNotNull(userId.toString());
+
+        final PlatformId<User> userId2 = PlatformId.fromUuid(uuid);
+
+        Assert.assertEquals(userId, userId2);
+    }
+
+    @Test
+    public void testDifferent()
+    {
+        final UUID uuid = UUID.randomUUID();
+        final UUID uuid2 = UUID.randomUUID();
+
+        final PlatformId<User> userId = PlatformId.fromUuid(uuid);
+        final PlatformId<User> userId2 = PlatformId.fromUuid(uuid2);
+        Assert.assertFalse(uuid.equals(uuid2));
+        Assert.assertFalse(userId.equals(userId2));
+        Assert.assertFalse(userId.getId().equals(userId2.getId()));
+    }
+
+    @Test
+    public void testMultitypes()
+    {
+        final TypeLiteral<PlatformId<User>> t1 = new TypeLiteral<PlatformId<User>>() {};
+        final TypeLiteral<PlatformId<Place>> t2 = new TypeLiteral<PlatformId<Place>>() {};
+
+        Assert.assertFalse(t1.equals(t2));
+    }
+
+    @Test
+    public void testBytes()
+    {
+        final UUID uuid = UUID.randomUUID();
+        final PlatformId<User> p1 = PlatformId.fromUuid(uuid);
+        final Function<PlatformId<User>, byte[]> f1 = PlatformId.toBytesFunction();
+        final Function<byte [], PlatformId<User>> f2 = PlatformId.fromBytesFunction();
+        final PlatformId<User> p2 = f2.apply(f1.apply(p1));
+        Assert.assertEquals(p1, p2);
+    }
+
+    @Test
+    public void testString()
+    {
+        final UUID uuid = UUID.randomUUID();
+        final PlatformId<User> p1 = PlatformId.fromUuid(uuid);
+        final Function<PlatformId<User>, String> f1 = PlatformId.toStringFunction();
+        final Function<String, PlatformId<User>> f2 = PlatformId.fromStringFunction();
+        final PlatformId<User> p2 = f2.apply(f1.apply(p1));
+        Assert.assertEquals(p1, p2);
+    }
+
+    @Test
+    public void testUUID()
+    {
+        final UUID uuid = UUID.randomUUID();
+        final PlatformId<User> p1 = PlatformId.fromUuid(uuid);
+        final Function<PlatformId<User>, UUID> f1 = PlatformId.toUuidFunction();
+        final Function<UUID, PlatformId<User>> f2 = PlatformId.fromUuidFunction();
+        final PlatformId<User> p2 = f2.apply(f1.apply(p1));
+        Assert.assertEquals(p1, p2);
+    }
+
+    @Test
+    public void testBytesNull()
+    {
+        final PlatformId<User> nullId = PlatformId.valueOf(null);
+        final PlatformId<User> p1 = null;
+        final Function<PlatformId<User>, byte[]> f1 = PlatformId.toBytesFunction();
+        final Function<byte [], PlatformId<User>> f2 = PlatformId.fromBytesFunction();
+        final byte [] value = f1.apply(p1);
+        Assert.assertNull(value);
+        final PlatformId<User> p2 = f2.apply(value);
+        Assert.assertEquals(nullId, p2);
+    }
+
+    @Test
+    public void testStringNull()
+    {
+        final PlatformId<User> nullId = PlatformId.valueOf(null);
+        final PlatformId<User> p1 = null;
+        final Function<PlatformId<User>, String> f1 = PlatformId.toStringFunction();
+        final Function<String, PlatformId<User>> f2 = PlatformId.fromStringFunction();
+        final String value = f1.apply(p1);
+        Assert.assertNull(value);
+        final PlatformId<User> p2 = f2.apply(value);
+        Assert.assertEquals(nullId, p2);
+    }
+
+    @Test
+    public void testUUIDNull()
+    {
+        final PlatformId<User> nullId = PlatformId.valueOf(null);
+        final PlatformId<User> p1 = null;
+        final Function<PlatformId<User>, UUID> f1 = PlatformId.toUuidFunction();
+        final Function<UUID, PlatformId<User>> f2 = PlatformId.fromUuidFunction();
+        final UUID value = f1.apply(p1);
+        Assert.assertNull(value);
+        final PlatformId<User> p2 = f2.apply(value);
+        Assert.assertEquals(nullId, p2);
+    }
+
+
+    public static interface User
+    {
+    }
+
+    public static interface Place
+    {
+    }
+}
+
+

--- a/src/test/java/com/nesscomputing/types/TestStringId.java
+++ b/src/test/java/com/nesscomputing/types/TestStringId.java
@@ -1,0 +1,85 @@
+package com.nesscomputing.types;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Function;
+import com.google.inject.TypeLiteral;
+
+public class TestStringId
+{
+    @Test
+    public void testBasic()
+    {
+        final String val1 = "val1";
+
+        final StringId<User> userId = StringId.valueOf(val1);
+        Assert.assertNotNull(userId);
+        Assert.assertEquals(val1, userId.getValue());
+
+        final StringId<User> userId2 = StringId.valueOf(val1);
+
+        Assert.assertEquals(userId, userId2);
+    }
+
+    public void testNull()
+    {
+        Assert.assertNull(StringId.valueOf(null));
+    }
+
+    @Test
+    public void testDifferent()
+    {
+        final String val1 = "val1";
+        final String val2 = "val2";
+
+        final StringId<User> userId = StringId.valueOf(val1);
+        final StringId<User> userId2 = StringId.valueOf(val2);
+        Assert.assertFalse(val1.equals(val2));
+        Assert.assertFalse(userId.equals(userId2));
+        Assert.assertFalse(userId.getValue().equals(userId2.getValue()));
+    }
+
+    @Test
+    public void testMultitypes()
+    {
+        final TypeLiteral<StringId<User>> t1 = new TypeLiteral<StringId<User>>() {};
+        final TypeLiteral<StringId<Place>> t2 = new TypeLiteral<StringId<Place>>() {};
+
+        Assert.assertFalse(t1.equals(t2));
+    }
+
+    @Test
+    public void testString()
+    {
+        final String val1 = "val1";
+        final StringId<User> p1 = StringId.valueOf(val1);
+        final Function<StringId<User>, String> f1 = StringId.toStringFunction();
+        final Function<String, StringId<User>> f2 = StringId.fromStringFunction();
+        final StringId<User> p2 = f2.apply(f1.apply(p1));
+        Assert.assertEquals(p1, p2);
+    }
+
+    @Test
+    public void testNullOk()
+    {
+        final StringId<User> p1 = null;
+        final Function<StringId<User>, String> f1 = StringId.toStringFunction();
+        final Function<String, StringId<User>> f2 = StringId.fromStringFunction();
+        final String value = f1.apply(p1);
+        Assert.assertNull(value);
+        final StringId<User> p2 = f2.apply(value);
+        Assert.assertNull(p2);
+    }
+
+
+    public static interface User
+    {
+    }
+
+    public static interface Place
+    {
+    }
+}
+
+

--- a/src/test/java/com/nesscomputing/types/TestStringId.java
+++ b/src/test/java/com/nesscomputing/types/TestStringId.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nesscomputing.types;
 
 import org.junit.Assert;

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2012 Ness Computing, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!--
+  This is the default logging setup for test cases.
+
+  If more/less logging is required, enable disable it on a per component base.
+-->
+
+<log4j:configuration
+    xmlns:log4j="http://jakarta.apache.org/log4j/"
+    threshold="trace">
+
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <param name="immediateFlush" value="true"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <!-- the following line contains tabs. They are used for grepp'ing through the output, -->
+            <!-- so *DON'T* replace them with spaces! -->
+            <param name="ConversionPattern" value="%p	%d{ISO8601}	%t	%c	%m%n" />
+        </layout>
+    </appender>
+
+    <logger name="com.nesscomputing">
+        <level value="debug" />
+    </logger>
+
+    <root>
+        <level value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
Null value handling for PlatformId now same as StringId. Removed optional from jackson-core dep.
