### PR TITLE
Adding custom UUID deserialization to avoid object allocations in java.util.UUID.fromString

### DIFF
--- a/src/main/java/com/nesscomputing/uuid/NessUUID.java
+++ b/src/main/java/com/nesscomputing/uuid/NessUUID.java
@@ -17,6 +17,19 @@ package com.nesscomputing.uuid;
 
 import java.util.UUID;
 
+
+/**
+ * A class that provides an alternate implementation of {@link
+ * java.util.UUID#fromString(String)}.
+ *
+ * <p> The version in the JDK uses {@link java.lang.String#split(String)}
+ * which does not compile the regular expression that is used for splitting
+ * the UUID string and results in the allocation of multiple strings in a
+ * string array. We decided to write {@link NessUUID} when we ran into
+ * performance issues with the garbage produced by {@link
+ * java.util.UUID#fromString(String)}.
+ *
+ */
 public class NessUUID {
     private NessUUID() {}
 

--- a/src/main/java/com/nesscomputing/uuid/NessUUID.java
+++ b/src/main/java/com/nesscomputing/uuid/NessUUID.java
@@ -1,0 +1,61 @@
+package com.nesscomputing.uuid;
+
+import java.util.UUID;
+
+public class NessUUID {
+    private NessUUID() {}
+
+    private static final byte[] CHAR_MAP = new byte[Character.MAX_VALUE];
+
+    static {
+        for (int i = 0; i < Character.MAX_VALUE; i++) {
+            CHAR_MAP[i] = -1;
+        }
+        initCharMap('a', 'f', 10);
+        initCharMap('A', 'F', 10);
+        initCharMap('0', '9', 0);
+    }
+
+    public static UUID fromString(String str) {
+        if (str.length() != 36 ||
+            str.charAt(8) != '-' ||
+            str.charAt(13) != '-' ||
+            str.charAt(18) != '-' ||
+            str.charAt(23) != '-') {
+            throw new IllegalArgumentException("Invalid UUID string: " + str);
+        }
+
+        long mostSigBits = decode(str, 0, 8);
+        mostSigBits <<= 16;
+        mostSigBits |= decode(str, 9, 4);
+        mostSigBits <<= 16;
+        mostSigBits |= decode(str, 14, 4);
+
+        long leastSigBits = decode(str, 19, 4);
+        leastSigBits <<= 48;
+        leastSigBits |= decode(str, 24, 12);
+
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    private static long decode(final String str, final int offset, final int length) {
+        long curr = 0;
+        for (int i = 0; i < length; i++) {
+            byte v = CHAR_MAP[str.charAt(i + offset)];
+            if (v == -1) {
+                throw new IllegalArgumentException("Invalid UUID string: " + str);
+            }
+            curr |= v;
+            curr <<= 4;
+        }
+        // won't be enough precision for all inputs, but will be enough precision for the inputs we expect.
+        curr >>= 4;
+        return curr;
+    }
+
+    private static void initCharMap(final char a, final char b, final int offset) {
+        for (int i = a; i <= b; i++) {
+            CHAR_MAP[i] = (byte) ((i - a) + offset);
+        }
+    }
+}

--- a/src/main/java/com/nesscomputing/uuid/NessUUID.java
+++ b/src/main/java/com/nesscomputing/uuid/NessUUID.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nesscomputing.uuid;
 
 import java.util.UUID;

--- a/src/test/java/com/nesscomputing/uuid/TestNessUUID.java
+++ b/src/test/java/com/nesscomputing/uuid/TestNessUUID.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 public class TestNessUUID {
     private final String uuid = "6f32f693-c7b5-11e1-afa7-88af2abc9a66";
     private final String caseSensitivity = "Dd000000-0000-0000-0000-000000000000";
+    private final String overflow = "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+    private final String zero = "00000000-0000-0000-0000-000000000000";
     private final String badLength = "00000000-f0000-0000-0000-000000000000";
     private final String hyphen1 = "00000000f0000-0000-0000-000000000000";
     private final String hyphen2 = "00000000-0000f0000-0000-000000000000";
@@ -40,6 +42,8 @@ public class TestNessUUID {
     {
         Assert.assertEquals(UUID.fromString(uuid), NessUUID.fromString(uuid));
         Assert.assertEquals(UUID.fromString(caseSensitivity), NessUUID.fromString(caseSensitivity));
+        Assert.assertEquals(UUID.fromString(overflow), NessUUID.fromString(overflow));
+        Assert.assertEquals(UUID.fromString(zero), NessUUID.fromString(zero));
     }
 
     @Test(expected=IllegalArgumentException.class)

--- a/src/test/java/com/nesscomputing/uuid/TestNessUUID.java
+++ b/src/test/java/com/nesscomputing/uuid/TestNessUUID.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2012 Ness Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nesscomputing.uuid;
+
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestNessUUID {
+    private final String uuid = "6f32f693-c7b5-11e1-afa7-88af2abc9a66";
+    private final String caseSensitivity = "Dd000000-0000-0000-0000-000000000000";
+    private final String badLength = "00000000-f0000-0000-0000-000000000000";
+    private final String hyphen1 = "00000000f0000-0000-0000-000000000000";
+    private final String hyphen2 = "00000000-0000f0000-0000-000000000000";
+    private final String hyphen3 = "00000000-0000-0000f0000-000000000000";
+    private final String hyphen4 = "00000000-0000-0000-0000f000000000000";
+    private final String invalid1 = "00000000-0000-0-00-0000-000000000000";
+    private final String invalid2 = "0000g000-0000-0000-0000-000000000000";
+    private final String invalid3 = "00000000-00g0-0000-0000-000000000000";
+    private final String invalid4 = "00000000-0000-0g00-0000-000000000000";
+    private final String invalid5 = "00000000-0000-0000-00g0-000000000000";
+    private final String invalid6 = "00000000-0000-0000-0000-0000000000g0";
+
+    @Test
+    public void testBasic()
+    {
+        Assert.assertEquals(UUID.fromString(uuid), NessUUID.fromString(uuid));
+        Assert.assertEquals(UUID.fromString(caseSensitivity), NessUUID.fromString(caseSensitivity));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testLength() {
+        NessUUID.fromString(badLength);
+    }
+
+    @Test
+    public void testHyphen() {
+        testEx(hyphen1);
+        testEx(hyphen2);
+        testEx(hyphen3);
+        testEx(hyphen4);
+    }
+
+    @Test
+    public void invalid() {
+        testEx(invalid1);
+        testEx(invalid2);
+        testEx(invalid3);
+        testEx(invalid4);
+        testEx(invalid5);
+        testEx(invalid6);
+    }
+
+    // makes testing multiple exceptions less verbose
+    private void testEx(String str) {
+        try {
+            NessUUID.fromString(hyphen1);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        Assert.fail(str);
+    }
+}


### PR DESCRIPTION
java.util.UUID.fromString fails to compile the regular expression used in its split and allocates multiple strings by splitting.
