### PR TITLE
BatchingCallback that delegates to an ExecutorService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <groupId>com.nesscomputing.components</groupId>
   <artifactId>ness-core</artifactId>
   <name>ness-core</name>
-  <version>1.6.2-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Ness base types component</description>
 

--- a/src/main/java/com/nesscomputing/callback/BatchingCallbackExecutionException.java
+++ b/src/main/java/com/nesscomputing/callback/BatchingCallbackExecutionException.java
@@ -1,0 +1,7 @@
+package com.nesscomputing.callback;
+
+public class BatchingCallbackExecutionException extends RuntimeException
+{
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/nesscomputing/callback/ExecutorBatchingCallback.java
+++ b/src/main/java/com/nesscomputing/callback/ExecutorBatchingCallback.java
@@ -1,0 +1,109 @@
+package com.nesscomputing.callback;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+class ExecutorBatchingCallback<T> extends BatchingCallback<T>
+{
+    ExecutorBatchingCallback(int size, ExecutorService executor, Callback<? super List<T>> out, boolean failFast)
+    {
+        super(size, new ExecutorCallback<>(executor, out, failFast));
+    }
+
+    @Override
+    public boolean commit()
+    {
+        boolean result = super.commit();
+        ExecutorCallback.class.cast(getOut()).close();
+        return result;
+    }
+
+    static class ExecutorCallback<T> implements Callback<List<T>>
+    {
+        private final ExecutorCompletionService<Void> executor;
+        private final Callback<? super List<T>> out;
+        private final AtomicLong inFlight = new AtomicLong();
+        private final BatchingCallbackExecutionException exceptions = new BatchingCallbackExecutionException();
+        private final AtomicBoolean failed = new AtomicBoolean();
+        private final boolean failFast;
+
+        ExecutorCallback(ExecutorService executor, Callback<? super List<T>> out, boolean failFast)
+        {
+            this.executor = new ExecutorCompletionService<Void>(executor);
+            this.out = out;
+            this.failFast = failFast;
+        }
+
+        @Override
+        public void call(final List<T> item) throws Exception
+        {
+            if (failed.get()) {
+                throw new CallbackRefusedException();
+            }
+
+            inFlight.incrementAndGet();
+            executor.submit(new ExecutorCallable<T>(out, item));
+
+            Future<Void> f;
+            while ( (f = executor.poll()) != null ) {
+                inFlight.decrementAndGet();
+                try {
+                    f.get();
+                } catch (ExecutionException e) {
+                    exceptions.addSuppressed(e.getCause());
+
+                    if (failFast) {
+                        failed.set(true);
+                        exceptions.fillInStackTrace();
+                        throw exceptions;
+                    }
+                }
+            }
+        }
+
+        public void close()
+        {
+            while (inFlight.decrementAndGet() > 0) {
+                try {
+                    executor.take().get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                } catch (ExecutionException e) {
+                    exceptions.addSuppressed(e.getCause());
+                }
+            }
+
+            if (exceptions.getSuppressed().length != 0) {
+                exceptions.fillInStackTrace();
+                throw exceptions;
+            }
+        }
+    }
+
+    static class ExecutorCallable<T> implements Callable<Void>
+    {
+        private final Callback<? super List<T>> out;
+        private final List<T> item;
+
+        ExecutorCallable(Callback<? super List<T>> out, List<T> item)
+        {
+            this.out = out;
+            this.item = item;
+        }
+
+        @Override
+        public Void call() throws Exception
+        {
+            out.call(item);
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/nesscomputing/callback/TestExecutorBatchingCallback.java
+++ b/src/test/java/com/nesscomputing/callback/TestExecutorBatchingCallback.java
@@ -1,0 +1,116 @@
+package com.nesscomputing.callback;
+
+import static com.google.common.collect.ImmutableList.of;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import org.junit.Test;
+
+public class TestExecutorBatchingCallback
+{
+    @Test
+    public void testGood() throws Exception
+    {
+        ExecutorService executor = MoreExecutors.sameThreadExecutor();
+        CallbackCollector<List<String>> out = new CallbackCollector<>();
+        BatchingCallback<String> batcher = BatchingCallback.batchInto(2, executor, out, false);
+
+        batcher.call("a");
+        batcher.call("b");
+        batcher.call("c");
+        batcher.call("d");
+        batcher.call("e");
+
+        batcher.commit();
+
+        assertEquals(of(of("a", "b"), of("c", "d"), of("e")), out.getItems());
+    }
+
+    @Test
+    public void testFailSlow() throws Exception
+    {
+        final Exception e1 = new Exception();
+        final Exception e2 = new Exception();
+
+        ExecutorService executor = MoreExecutors.sameThreadExecutor();
+        Callback<List<String>> out = new Callback<List<String>>() {
+            @Override
+            public void call(List<String> item) throws Exception
+            {
+                switch (item.get(0)) {
+                case "a":
+                    throw e1;
+                case "c":
+                    return;
+                case "e":
+                    throw e2;
+                }
+            }
+        };
+
+        BatchingCallback<String> batcher = BatchingCallback.batchInto(2, executor, out, false);
+
+        batcher.call("a");
+        batcher.call("b");
+        batcher.call("c");
+        batcher.call("d");
+        batcher.call("e");
+
+        try {
+            batcher.commit();
+            fail();
+        } catch (BatchingCallbackExecutionException bcee) {
+            assertEquals(2, bcee.getSuppressed().length);
+            assertSame(e1, bcee.getSuppressed()[0]);
+            assertSame(e2, bcee.getSuppressed()[1]);
+        }
+    }
+
+    @Test
+    public void testFailFast() throws Exception
+    {
+        final Exception e1 = new Exception();
+        final Exception e2 = new Exception();
+
+        ExecutorService executor = MoreExecutors.sameThreadExecutor();
+        Callback<List<String>> out = new Callback<List<String>>() {
+            @Override
+            public void call(List<String> item) throws Exception
+            {
+                switch (item.get(0)) {
+                case "a":
+                    throw e1;
+                case "c":
+                    return;
+                case "e":
+                    throw e2;
+                }
+            }
+        };
+
+        BatchingCallback<String> batcher = BatchingCallback.batchInto(2, executor, out, true);
+
+        batcher.call("a");
+        batcher.call("b");
+        try {
+            batcher.call("c");
+            fail();
+        } catch (BatchingCallbackExecutionException bcee) {
+            assertEquals(1, bcee.getSuppressed().length);
+            assertSame(e1, bcee.getSuppressed()[0]);
+        }
+        try {
+            batcher.call("d");
+            batcher.call("e");
+            batcher.call("f");
+            fail();
+        } catch (CallbackRefusedException e) {
+        }
+    }
+}


### PR DESCRIPTION
Now the BatchingCallback can automatically schedule batches for processing on a given ExecutorService.
